### PR TITLE
feat(makefile): added makefile for running make clippy, fmt, hack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,92 @@
+# = Parameters
+# Override envars using -e
+
+#
+# = Common
+#
+
+# Checks two given strings for equality.
+eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
+                                $(findstring $(2),$(1))),1)
+
+ROOT_DIR_WITH_SLASH := $(dir $(realpath $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR := $(realpath $(ROOT_DIR_WITH_SLASH))
+
+#
+# = Targets
+#
+.PHONY : \
+	build \
+	doc \
+	fmt \
+	clippy \
+	test \
+	nextest \
+	hack \
+	typos \
+
+# Compile application for running on local machine
+#
+# Usage :
+#	make build
+build :
+	cargo build
+
+# Generate crates documentation from Rust sources.
+#
+# Usage :
+#	make doc [private=(yes|no)] [open=(yes|no)] [clean=(no|yes)]
+doc :
+ifeq ($(clean),yes)
+	@rm -rf $(ROOT_DIR)/target/doc/
+endif
+	cargo doc --all-features --package router \
+		$(if $(call eq,$(private),no),,--document-private-items) \
+		$(if $(call eq,$(open),no),,--open)
+
+# Format Rust sources with rustfmt.
+#
+# Usage :
+#	make fmt [writing=(no|yes)]
+fmt :
+	cargo +nightly fmt --all $(if $(call eq,$(writing),yes),,-- --check)
+
+# Lint Rust sources with Clippy.
+#
+# Usage :
+#	make clippy
+clippy :
+	cargo clippy --all-features --all-targets -- -D warnings
+
+# Run Rust tests of project.
+#
+# Usage :
+#	make test
+
+test :
+	cargo test --all-features
+
+
+# Next-generation test runner for Rust.
+# cargo nextest ignores the doctests at the moment. So if you are using it locally you also have to run `cargo test --doc`.
+# Usage:
+# 	make nextest
+
+nextest:
+	cargo nextest run
+
+# Run format clippy test and tests.
+#
+# Usage :
+#	make precommit
+
+precommit : fmt clippy test
+
+
+hack:
+	cargo hack check --workspace --each-feature --no-dev-deps
+
+# This requires typos to be installed
+# this can be done via cargo install typos-cli
+typos:
+	typos -c $(ROOT_DIR)/.typos.toml


### PR DESCRIPTION
## Type of Change
<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [x] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Migrations
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

## Description
<!-- Describe your changes in detail -->
This will enable the commands like
`make clippy`
`make hack`
`make test`
`make fmt`

### Additional Changes

- [ ] This PR modifies the API contract
- [ ] This PR modifies the database schema
- [ ] This PR modifies application configuration/environment variables


## Motivation and Context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.

If you don't have an issue, we'd recommend starting with one first so the PR
can focus on the implementation (unless its an obvious bug or documentation fix
that will have little conversation).
-->
Will help to shorten the commands

## How did you test it?
<!--
Did you write an integration/unit/API test to verify the code changes?
Or did you test this change manually (provide relevant screenshots)?
-->


## Checklist
<!-- Put an `x` in the boxes that apply -->

- [ ] I formatted the code `cargo +nightly fmt --all`
- [ ] I addressed lints thrown by `cargo clippy`
- [ ] I reviewed submitted code
- [ ] I added unit tests for my changes where possible
- [ ] I added a [CHANGELOG](/CHANGELOG.md) entry if applicable
